### PR TITLE
Fixed cp for animated branch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,7 @@ copy_configs() {
   printf "\n\033[1;32mCopying config files...\033[0m\n"
 
   mkdir -p ~/.config/waybar
-  cp config.jsonc style.css theme.css ~/.config/waybar
+  cp config.jsonc style.css theme.css animation.css ~/.config/waybar
 
   mkdir -p ~/.config/waybar/themes
   cp -r themes/* ~/.config/waybar/themes


### PR DESCRIPTION
The install.sh was not copying the file correctly, leading to errors and waybar not launching. This fixes that