### PR TITLE
Update cpu-temp.sh

### DIFF
--- a/scripts/cpu-temp.sh
+++ b/scripts/cpu-temp.sh
@@ -2,70 +2,66 @@
 
 model=$(awk -F ': ' '/model name/{print $2}' /proc/cpuinfo | head -n 1 | sed 's/@.*//; s/ *\((R)\|(TM)\)//g; s/^[ \t]*//; s/[ \t]*$//')
 
-# Get CPU clock speeds
+# get CPU clock speeds
 get_cpu_frequency() {
   freqlist=$(awk '/cpu MHz/ {print $4}' /proc/cpuinfo)
-  maxfreq=$(sed 's/...$//' /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq 2>/dev/null || echo "N/A")
-  if [ -n "$freqlist" ]; then
-    average_freq=$(echo "$freqlist" | tr ' ' '\n' | awk "{sum+=\$1} END {printf \"%.0f/%s MHz\", sum/NR, \"$maxfreq\"}")
-  else
-    average_freq="N/A"
+  maxfreq=$(sed 's/...$//' /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)
+  if [ -z "$freqlist" ] || [ -z "$maxfreq" ]; then
+    echo "N/A"
+    return
   fi
+  average_freq=$(echo "$freqlist" | tr ' ' '\n' | awk "{sum+=\$1} END {printf \"%.0f/%s MHz\", sum/NR, $maxfreq}")
   echo "$average_freq"
 }
 
-# Get CPU temperature
+# get CPU temp
 get_cpu_temperature() {
-  temp=$(sensors | awk '/Package id 0/ {print $4}' | awk -F '[+.]' '{print $2}' 2>/dev/null)
+  temp=$(sensors | awk '/Package id 0/ {print $4}' | awk -F '[+.]' '{print $2}')
   if [[ -z "$temp" ]]; then
-    temp=$(sensors | awk '/Tctl/ {print $2}' | tr -d '+°C' 2>/dev/null)
+    temp=$(sensors | awk '/Tctl/ {print $2}' | tr -d '+°C')
   fi
-  if [[ -z "$temp" || ! "$temp" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+  if [[ -z "$temp" ]]; then
     temp="N/A"
     temp_f="N/A"
   else
-    # Convertir a entero para comparaciones, pero mantener decimal para mostrar
-    temp_int=${temp%.*}  # Tomar la parte entera
+    temp=${temp%.*}
     temp_f=$(awk "BEGIN {printf \"%.1f\", ($temp * 9 / 5) + 32}")
   fi
-  echo "$temp $temp_f $temp_int"
+  # Celsius and Fahrenheit
+  echo "${temp:-N/A} ${temp_f:-N/A}"
 }
 
-# Get the corresponding icon based on temperature
 get_temperature_icon() {
   temp_value=$1
   if [ "$temp_value" = "N/A" ]; then
-    icon="󱃃" # Default icon when temp is not available
+    icon="󱔱" # none
   elif [ "$temp_value" -ge 80 ]; then
-    icon="󰸁" # High temperature
+    icon="󰸁" # high
   elif [ "$temp_value" -ge 70 ]; then
-    icon="󱃂" # Medium temperature
+    icon="󱃂" # medium
   elif [ "$temp_value" -ge 60 ]; then
-    icon="󰔏" # Normal temperature
+    icon="󰔏" # normal
   else
-    icon="󱃃" # Low temperature
+    icon="󱃃" # low
   fi
   echo "$icon"
 }
 
-# Main script execution
 cpu_frequency=$(get_cpu_frequency)
-read -r temp temp_f temp_int < <(get_cpu_temperature)
+read -r temp_info < <(get_cpu_temperature)
+temp=$(echo "$temp_info" | awk '{print $1}')
+temp_f=$(echo "$temp_info" | awk '{print $2}')
+thermo_icon=$(get_temperature_icon "$temp")
 
-# Determine the temperature icon using the integer value
-thermo_icon=$(get_temperature_icon "${temp_int:-0}")
-
-# Set color based on temperature
-if [ "$temp_int" != "N/A" ] && [ "$temp_int" -ge 80 ]; then
-  # If temperature is >= 80°C, set color to #f38ba8
+# high temp warning
+if [ "$temp" != "N/A" ] && [ "$temp" -ge 80 ]; then
   text_output="<span color='#f38ba8'>${thermo_icon} ${temp}°C</span>"
 else
-  # Default color
   text_output="${thermo_icon} ${temp}°C"
 fi
 
-tooltip="${model}\n"
+tooltip=":: ${model}\n"
 tooltip+="Clock Speed: ${cpu_frequency}\nTemperature: ${temp_f}°F"
 
-# Module and tooltip
+# module and tooltip
 echo "{\"text\": \"$text_output\", \"tooltip\": \"$tooltip\"}"

--- a/scripts/cpu-temp.sh
+++ b/scripts/cpu-temp.sh
@@ -5,29 +5,38 @@ model=$(awk -F ': ' '/model name/{print $2}' /proc/cpuinfo | head -n 1 | sed 's/
 # Get CPU clock speeds
 get_cpu_frequency() {
   freqlist=$(awk '/cpu MHz/ {print $4}' /proc/cpuinfo)
-  maxfreq=$(sed 's/...$//' /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)
-  average_freq=$(echo "$freqlist" | tr ' ' '\n' | awk "{sum+=\$1} END {printf \"%.0f/%s MHz\", sum/NR, $maxfreq}")
+  maxfreq=$(sed 's/...$//' /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq 2>/dev/null || echo "N/A")
+  if [ -n "$freqlist" ]; then
+    average_freq=$(echo "$freqlist" | tr ' ' '\n' | awk "{sum+=\$1} END {printf \"%.0f/%s MHz\", sum/NR, \"$maxfreq\"}")
+  else
+    average_freq="N/A"
+  fi
   echo "$average_freq"
 }
 
 # Get CPU temperature
 get_cpu_temperature() {
-  temp=$(sensors | awk '/Package id 0/ {print $4}' | awk -F '[+.]' '{print $2}')
+  temp=$(sensors | awk '/Package id 0/ {print $4}' | awk -F '[+.]' '{print $2}' 2>/dev/null)
   if [[ -z "$temp" ]]; then
-    temp=$(sensors | awk '/Tctl/ {print $2}' | tr -d '+°C')
+    temp=$(sensors | awk '/Tctl/ {print $2}' | tr -d '+°C' 2>/dev/null)
   fi
-  if [[ -z "$temp" ]]; then
+  if [[ -z "$temp" || ! "$temp" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
     temp="N/A"
+    temp_f="N/A"
   else
+    # Convertir a entero para comparaciones, pero mantener decimal para mostrar
+    temp_int=${temp%.*}  # Tomar la parte entera
     temp_f=$(awk "BEGIN {printf \"%.1f\", ($temp * 9 / 5) + 32}")
   fi
-  echo "${temp:-N/A} ${temp_f:-N/A}"
+  echo "$temp $temp_f $temp_int"
 }
 
 # Get the corresponding icon based on temperature
 get_temperature_icon() {
   temp_value=$1
-  if [ "$temp_value" -ge 80 ]; then
+  if [ "$temp_value" = "N/A" ]; then
+    icon="󱃃" # Default icon when temp is not available
+  elif [ "$temp_value" -ge 80 ]; then
     icon="󰸁" # High temperature
   elif [ "$temp_value" -ge 70 ]; then
     icon="󱃂" # Medium temperature
@@ -41,23 +50,21 @@ get_temperature_icon() {
 
 # Main script execution
 cpu_frequency=$(get_cpu_frequency)
-read -r temp_info < <(get_cpu_temperature)
-temp=$(echo "$temp_info" | awk '{print $1}')   # Celsius
-temp_f=$(echo "$temp_info" | awk '{print $2}') # Fahrenheit
+read -r temp temp_f temp_int < <(get_cpu_temperature)
 
-# Determine the temperature icon
-thermo_icon=$(get_temperature_icon "$temp")
+# Determine the temperature icon using the integer value
+thermo_icon=$(get_temperature_icon "${temp_int:-0}")
 
 # Set color based on temperature
-if [ "$temp" -ge 80 ]; then
-  # If temperature is >= 80%, set color to #f38ba8
+if [ "$temp_int" != "N/A" ] && [ "$temp_int" -ge 80 ]; then
+  # If temperature is >= 80°C, set color to #f38ba8
   text_output="<span color='#f38ba8'>${thermo_icon} ${temp}°C</span>"
 else
   # Default color
   text_output="${thermo_icon} ${temp}°C"
 fi
 
-tooltip=":: ${model}\n"
+tooltip="${model}\n"
 tooltip+="Clock Speed: ${cpu_frequency}\nTemperature: ${temp_f}°F"
 
 # Module and tooltip


### PR DESCRIPTION
Issue Description
The script cpu-temp.sh fails with errors like:

cpu-temp.sh: line 30: [: 49.6: integer expression expected

This occurs because the script attempts to perform integer comparisons (e.g., -ge) with temperature values extracted from sensors, which are often floating-point numbers (e.g., 49.6°C). Bash does not support floating-point comparisons natively with these operators, leading to the error. Additionally, the script lacks robust handling for cases where temperature data is unavailable or malformed.

Proposed Fix
The corrected version:

Extracts the temperature as both a decimal (for display) and an integer (for comparisons). Uses the integer value (temp_int) for all numeric comparisons to avoid floating-point issues. Adds error handling for cases where temperature or frequency data is unavailable, ensuring the script doesn't fail unexpectedly.