### PR TITLE
fix: replace killall with pkill for NixOS compatibility

### DIFF
--- a/scripts/theme-switcher.sh
+++ b/scripts/theme-switcher.sh
@@ -50,5 +50,5 @@ for src in "${!theme_files[@]}"; do
 done
 
 # Restart Waybar to apply changes
-killall waybar || true
+pkill waybar 2>/dev/null || true
 nohup waybar --config "$HOME/.config/waybar/config.jsonc" --style "$HOME/.config/waybar/style.css" >/dev/null 2>&1 &


### PR DESCRIPTION
Thanks you for these awesome config files!

### Problem
The `killall waybar` command fails on NixOS because waybar runs as `.waybar-wrapped` due to the Nix wrapper system. This prevents proper theme switching as the old waybar process isn't terminated.

When clicking the theme switcher button, this results in duplicate waybars.

### Solution  
Replace `killall waybar` with `pkill waybar` which uses pattern matching and works regardless of process name or wrapper systems.

### Changes
- Replace `killall waybar || true` with `pkill waybar 2>/dev/null || true`
- More portable across different Linux distributions
- Properly terminates waybar on NixOS, Arch, Ubuntu, etc.

### Testing
Tested on NixOS where the issue was preventing theme switching from working correctly.


### Terminal outputs
```bash
at 10:55:54 ✗  ps aux | grep waybar
basnijh+  408310  0.5  0.1 1315880 65464 pts/5   Sl   10:52   0:02 waybar --config /home/basnijholt/.config/waybar/config.jsonc --style /home/basnijholt/.config/waybar/style.css
at 10:55:54 ✗  ps aux | grep waybar
basnijh+  408310  0.5  0.1 1315880 65464 pts/5   Sl   10:52   0:02 waybar --config /home/basnijholt/.config/waybar/config.jsonc --style /home/basnijholt/.config/waybar/style.css
```
This demonstrates the problem.