### PR TITLE
fix(wifi): handle multiple connected network interfaces

### DIFF
--- a/scripts/wifi-status.sh
+++ b/scripts/wifi-status.sh
@@ -96,7 +96,8 @@ else
   active_device=$(nmcli -t -f DEVICE,STATE device status |
     grep -w "connected" |
     grep -v -E "^(dummy|lo:|virbr0)" |
-    awk -F: '{print $1}')
+    awk -F: '{print $1}' |
+    head -n 1)
 
   if [ -n "$active_device" ]; then
     output=$(nmcli -e no -g ip4.address,ip4.gateway,general.hwaddr device show "$active_device")


### PR DESCRIPTION
The `wifi-status.sh` script previously failed when multiple network interfaces were connected, with the following error:

```
Error: Device 'wlp6s0
br-d8cff23ece8d
docker0' not found.
```

This was because the active_device variable was assigned a multi-line string containing all connected interfaces, which was then passed to `nmcli device show`, causing the error.

This change fixes the issue by piping the output of the nmcli command to `head -n 1`, ensuring that only the first active device is selected. This makes the script more robust and prevents it from failing in environments with multiple network connections, such as those with Docker or virtual machine bridges.