### PR TITLE
feat(tooltips): enable tooltips for cpu and memory modules

### DIFF
--- a/modules/cpu.jsonc
+++ b/modules/cpu.jsonc
@@ -1,7 +1,8 @@
 {
   "cpu": {
     "format": "󰻠 {usage}%",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "CPU: {usage}%",
     "interval": 5,
     "min-length": 6,
     "max-length": 6

--- a/modules/memory.jsonc
+++ b/modules/memory.jsonc
@@ -7,8 +7,8 @@
 
     "format": "󰘚 {percentage}%",
     "format-critical": "󰀦 {percentage}%",
-    "tooltip": false,
-    // "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
+    "tooltip": true,
+    "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
     "interval": 5,
     "min-length": 7,
     "max-length": 7

--- a/themes/jsonc/catppuccin-frappe.jsonc
+++ b/themes/jsonc/catppuccin-frappe.jsonc
@@ -215,8 +215,8 @@
 
     "format": "󰘚 {percentage}%",
     "format-critical": "󰀦 {percentage}%",
-    "tooltip": false,
-    // "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
+    "tooltip": true,
+    "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
     "interval": 5,
     "min-length": 7,
     "max-length": 7
@@ -226,7 +226,8 @@
 
   "cpu": {
     "format": "󰍛 {usage}%",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "CPU: {usage}%",
     "interval": 5,
     "min-length": 6,
     "max-length": 6

--- a/themes/jsonc/catppuccin-latte.jsonc
+++ b/themes/jsonc/catppuccin-latte.jsonc
@@ -215,8 +215,8 @@
 
     "format": "󰘚 {percentage}%",
     "format-critical": "󰀦 {percentage}%",
-    "tooltip": false,
-    // "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
+    "tooltip": true,
+    "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
     "interval": 5,
     "min-length": 7,
     "max-length": 7
@@ -226,7 +226,8 @@
 
   "cpu": {
     "format": "󰍛 {usage}%",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "CPU: {usage}%",
     "interval": 5,
     "min-length": 6,
     "max-length": 6

--- a/themes/jsonc/catppuccin-macchiato.jsonc
+++ b/themes/jsonc/catppuccin-macchiato.jsonc
@@ -215,8 +215,8 @@
 
     "format": "󰘚 {percentage}%",
     "format-critical": "󰀦 {percentage}%",
-    "tooltip": false,
-    // "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
+    "tooltip": true,
+    "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
     "interval": 5,
     "min-length": 7,
     "max-length": 7
@@ -226,7 +226,8 @@
 
   "cpu": {
     "format": "󰍛 {usage}%",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "CPU: {usage}%",
     "interval": 5,
     "min-length": 6,
     "max-length": 6

--- a/themes/jsonc/catppuccin-mocha.jsonc
+++ b/themes/jsonc/catppuccin-mocha.jsonc
@@ -215,8 +215,8 @@
 
     "format": "󰘚 {percentage}%",
     "format-critical": "󰀦 {percentage}%",
-    "tooltip": false,
-    // "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
+    "tooltip": true,
+    "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
     "interval": 5,
     "min-length": 7,
     "max-length": 7
@@ -226,7 +226,8 @@
 
   "cpu": {
     "format": "󰍛 {usage}%",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "CPU: {usage}%",
     "interval": 5,
     "min-length": 6,
     "max-length": 6

--- a/themes/jsonc/gruvbox-dark.jsonc
+++ b/themes/jsonc/gruvbox-dark.jsonc
@@ -215,8 +215,8 @@
 
     "format": "󰘚 {percentage}%",
     "format-critical": "󰀦 {percentage}%",
-    "tooltip": false,
-    // "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
+    "tooltip": true,
+    "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
     "interval": 5,
     "min-length": 7,
     "max-length": 7
@@ -226,7 +226,8 @@
 
   "cpu": {
     "format": "󰍛 {usage}%",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "CPU: {usage}%",
     "interval": 5,
     "min-length": 6,
     "max-length": 6

--- a/themes/jsonc/gruvbox-light.jsonc
+++ b/themes/jsonc/gruvbox-light.jsonc
@@ -215,8 +215,8 @@
 
     "format": "󰘚 {percentage}%",
     "format-critical": "󰀦 {percentage}%",
-    "tooltip": false,
-    // "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
+    "tooltip": true,
+    "tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB",
     "interval": 5,
     "min-length": 7,
     "max-length": 7
@@ -226,7 +226,8 @@
 
   "cpu": {
     "format": "󰍛 {usage}%",
-    "tooltip": false,
+    "tooltip": true,
+    "tooltip-format": "CPU: {usage}%",
     "interval": 5,
     "min-length": 6,
     "max-length": 6


### PR DESCRIPTION
Hi sejjy,

I've enabled the tooltips for the CPU and memory modules. This provides some extra information on hover, which I find quite useful.

It seems you already had support for the memory tooltip, but it was commented out. I've enabled it and also added it for the CPU module. It's a nice little addition that doesn't have any performance impact.

Let me know what you think