### PR TITLE
feat(gpu): add gpu usage module

### DIFF
--- a/animation.css
+++ b/animation.css
@@ -33,6 +33,7 @@
 }
 
 #cpu,
+#custom-gpu,
 #clock.time {
   font-size: 0;
   text-shadow: none;

--- a/modules/custom/gpu.jsonc
+++ b/modules/custom/gpu.jsonc
@@ -1,0 +1,10 @@
+{
+  "custom/gpu": {
+    "exec": "~/.config/waybar/scripts/gpu-usage.sh",
+    "return-type": "json",
+    "format": "{}",
+    "interval": 5,
+    "min-length": 6,
+    "max-length": 6
+  }
+}

--- a/scripts/gpu-usage.sh
+++ b/scripts/gpu-usage.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+gpu_info=$(nvidia-smi --query-gpu=gpu_name,temperature.gpu,memory.used,memory.total,utilization.gpu --format=csv,noheader,nounits)
+gpu_name=$(echo "$gpu_info" | cut -d ',' -f 1)
+gpu_temp=$(echo "$gpu_info" | cut -d ',' -f 2)
+gpu_mem_used=$(echo "$gpu_info" | cut -d ',' -f 3)
+gpu_mem_total=$(echo "$gpu_info" | cut -d ',' -f 4)
+gpu_usage=$(echo "$gpu_info" | cut -d ',' -f 5)
+
+tooltip="$gpu_name\n"
+tooltip+="Temp: ${gpu_temp}°C\n"
+tooltip+="Mem: ${gpu_mem_used}MiB / ${gpu_mem_total}MiB\n"
+tooltip+="Usage: ${gpu_usage}%"
+
+printf '{"text": "󰾲 %s%%", "tooltip": "%s"}\n' "$gpu_usage" "$tooltip"

--- a/style.css
+++ b/style.css
@@ -43,6 +43,7 @@ tooltip label {
 #custom-temperature,
 #memory,
 #cpu,
+#custom-gpu,
 #idle_inhibitor,
 #clock,
 #custom-wifi,
@@ -62,6 +63,7 @@ tooltip label {
 #custom-left2,
 #custom-left3,
 #custom-left4,
+#custom-left4_5,
 #custom-left5,
 #custom-left6,
 #custom-left7,
@@ -184,8 +186,18 @@ tooltip label {
   background: @cpu;
 }
 
+#custom-left4_5 {
+  color: @gpu;
+  background: @cpu;
+  padding-left: 3px;
+}
+
+#custom-gpu {
+  background: @gpu;
+}
+
 #custom-leftin1 {
-  color: @cpu;
+  color: @gpu;
   margin-bottom: -1px;
 }
 
@@ -412,6 +424,7 @@ tooltip label,
 #custom-left2,
 #custom-left3,
 #custom-left4,
+#custom-left4_5,
 #custom-left5,
 #custom-left6,
 #custom-left7,

--- a/themes/css/catppuccin-frappe.css
+++ b/themes/css/catppuccin-frappe.css
@@ -57,6 +57,7 @@
 @define-color temperature     @mantle;
 @define-color memory          @base;
 @define-color cpu             @surface0;
+@define-color gpu             @surface1;
 @define-color distro-fg       @black;
 @define-color distro-bg       @overlay2;
 @define-color time            @surface0;

--- a/themes/css/catppuccin-latte.css
+++ b/themes/css/catppuccin-latte.css
@@ -57,6 +57,7 @@
 @define-color temperature     @mantle;
 @define-color memory          @base;
 @define-color cpu             @surface0;
+@define-color gpu             @surface1;
 @define-color distro-fg       @black;
 @define-color distro-bg       @overlay2;
 @define-color time            @surface0;

--- a/themes/css/catppuccin-macchiato.css
+++ b/themes/css/catppuccin-macchiato.css
@@ -57,6 +57,7 @@
 @define-color temperature     @mantle;
 @define-color memory          @base;
 @define-color cpu             @surface0;
+@define-color gpu             @surface1;
 @define-color distro-fg       @black;
 @define-color distro-bg       @overlay2;
 @define-color time            @surface0;

--- a/themes/css/catppuccin-mocha.css
+++ b/themes/css/catppuccin-mocha.css
@@ -57,6 +57,7 @@
 @define-color temperature     @mantle;
 @define-color memory          @base;
 @define-color cpu             @surface0;
+@define-color gpu             @surface1;
 @define-color distro-fg       @black;
 @define-color distro-bg       @overlay2;
 @define-color time            @surface0;

--- a/themes/css/gruvbox-dark.css
+++ b/themes/css/gruvbox-dark.css
@@ -57,6 +57,7 @@
 @define-color temperature     @bg0;
 @define-color memory          @bg1;
 @define-color cpu             @bg2;
+@define-color gpu             @bg3;
 @define-color distro-fg       @black;
 @define-color distro-bg       @yellow;
 @define-color time            @bg2;

--- a/themes/css/gruvbox-light.css
+++ b/themes/css/gruvbox-light.css
@@ -57,6 +57,7 @@
 @define-color temperature     @bg0;
 @define-color memory          @bg1;
 @define-color cpu             @bg2;
+@define-color gpu             @bg3;
 @define-color distro-fg       @black;
 @define-color distro-bg       @yellow;
 @define-color time            @bg2;

--- a/themes/jsonc/catppuccin-frappe.jsonc
+++ b/themes/jsonc/catppuccin-frappe.jsonc
@@ -30,6 +30,9 @@
 
     "custom/left4",
     "cpu",                  // cpu
+
+    "custom/left4_5",
+    "custom/gpu",           // gpu
     "custom/leftin1",
 
     "custom/left5",
@@ -230,6 +233,18 @@
     "interval": 5,
     "min-length": 6,
     "max-length": 6
+  },
+
+  // ────────────────────────────────────────────────────────────────┤ gpu ├───
+
+  "custom/gpu": {
+    "exec": "~/.config/waybar/scripts/gpu-usage.sh",
+    "return-type": "json",
+    "format": "{}",
+    "interval": 5,
+    "min-length": 6,
+    "max-length": 6,
+    "tooltip": true
   },
 
   // ─────────────────────────────────────────────────────────────┤ distro ├───
@@ -453,6 +468,10 @@
     "tooltip": false
   },
   "custom/left4": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/left4_5": {
     "format": "",
     "tooltip": false
   },

--- a/themes/jsonc/catppuccin-latte.jsonc
+++ b/themes/jsonc/catppuccin-latte.jsonc
@@ -30,6 +30,9 @@
 
     "custom/left4",
     "cpu",                  // cpu
+
+    "custom/left4_5",
+    "custom/gpu",           // gpu
     "custom/leftin1",
 
     "custom/left5",
@@ -230,6 +233,18 @@
     "interval": 5,
     "min-length": 6,
     "max-length": 6
+  },
+
+  // ────────────────────────────────────────────────────────────────┤ gpu ├───
+
+  "custom/gpu": {
+    "exec": "~/.config/waybar/scripts/gpu-usage.sh",
+    "return-type": "json",
+    "format": "{}",
+    "interval": 5,
+    "min-length": 6,
+    "max-length": 6,
+    "tooltip": true
   },
 
   // ─────────────────────────────────────────────────────────────┤ distro ├───
@@ -453,6 +468,10 @@
     "tooltip": false
   },
   "custom/left4": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/left4_5": {
     "format": "",
     "tooltip": false
   },

--- a/themes/jsonc/catppuccin-macchiato.jsonc
+++ b/themes/jsonc/catppuccin-macchiato.jsonc
@@ -30,6 +30,9 @@
 
     "custom/left4",
     "cpu",                  // cpu
+
+    "custom/left4_5",
+    "custom/gpu",           // gpu
     "custom/leftin1",
 
     "custom/left5",
@@ -230,6 +233,18 @@
     "interval": 5,
     "min-length": 6,
     "max-length": 6
+  },
+
+  // ────────────────────────────────────────────────────────────────┤ gpu ├───
+
+  "custom/gpu": {
+    "exec": "~/.config/waybar/scripts/gpu-usage.sh",
+    "return-type": "json",
+    "format": "{}",
+    "interval": 5,
+    "min-length": 6,
+    "max-length": 6,
+    "tooltip": true
   },
 
   // ─────────────────────────────────────────────────────────────┤ distro ├───
@@ -453,6 +468,10 @@
     "tooltip": false
   },
   "custom/left4": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/left4_5": {
     "format": "",
     "tooltip": false
   },

--- a/themes/jsonc/catppuccin-mocha.jsonc
+++ b/themes/jsonc/catppuccin-mocha.jsonc
@@ -30,6 +30,9 @@
 
     "custom/left4",
     "cpu",                  // cpu
+
+    "custom/left4_5",
+    "custom/gpu",           // gpu
     "custom/leftin1",
 
     "custom/left5",
@@ -230,6 +233,18 @@
     "interval": 5,
     "min-length": 6,
     "max-length": 6
+  },
+
+  // ────────────────────────────────────────────────────────────────┤ gpu ├───
+
+  "custom/gpu": {
+    "exec": "~/.config/waybar/scripts/gpu-usage.sh",
+    "return-type": "json",
+    "format": "{}",
+    "interval": 5,
+    "min-length": 6,
+    "max-length": 6,
+    "tooltip": true
   },
 
   // ─────────────────────────────────────────────────────────────┤ distro ├───
@@ -453,6 +468,10 @@
     "tooltip": false
   },
   "custom/left4": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/left4_5": {
     "format": "",
     "tooltip": false
   },

--- a/themes/jsonc/gruvbox-dark.jsonc
+++ b/themes/jsonc/gruvbox-dark.jsonc
@@ -30,6 +30,9 @@
 
     "custom/left4",
     "cpu",                  // cpu
+
+    "custom/left4_5",
+    "custom/gpu",           // gpu
     "custom/leftin1",
 
     "custom/left5",
@@ -230,6 +233,18 @@
     "interval": 5,
     "min-length": 6,
     "max-length": 6
+  },
+
+  // ────────────────────────────────────────────────────────────────┤ gpu ├───
+
+  "custom/gpu": {
+    "exec": "~/.config/waybar/scripts/gpu-usage.sh",
+    "return-type": "json",
+    "format": "{}",
+    "interval": 5,
+    "min-length": 6,
+    "max-length": 6,
+    "tooltip": true
   },
 
   // ─────────────────────────────────────────────────────────────┤ distro ├───
@@ -453,6 +468,10 @@
     "tooltip": false
   },
   "custom/left4": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/left4_5": {
     "format": "",
     "tooltip": false
   },

--- a/themes/jsonc/gruvbox-light.jsonc
+++ b/themes/jsonc/gruvbox-light.jsonc
@@ -30,6 +30,9 @@
 
     "custom/left4",
     "cpu",                  // cpu
+
+    "custom/left4_5",
+    "custom/gpu",           // gpu
     "custom/leftin1",
 
     "custom/left5",
@@ -230,6 +233,18 @@
     "interval": 5,
     "min-length": 6,
     "max-length": 6
+  },
+
+  // ────────────────────────────────────────────────────────────────┤ gpu ├───
+
+  "custom/gpu": {
+    "exec": "~/.config/waybar/scripts/gpu-usage.sh",
+    "return-type": "json",
+    "format": "{}",
+    "interval": 5,
+    "min-length": 6,
+    "max-length": 6,
+    "tooltip": true
   },
 
   // ─────────────────────────────────────────────────────────────┤ distro ├───
@@ -453,6 +468,10 @@
     "tooltip": false
   },
   "custom/left4": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/left4_5": {
     "format": "",
     "tooltip": false
   },


### PR DESCRIPTION
Hi sejjy,

I've added a new module to display GPU usage, which I find very useful. It uses `nvidia-smi` to get the GPU information, so it will only work for NVIDIA GPUs.

I understand that this might be a niche feature and you may not want to merge it into the main project. If that's the case, feel free to close this pull request. 

Also, I hacked it in, so there are ugly names like `custom-left4_5`. In case you consider to actually merge this I will do it properly, just let me know! So for now I will open this PR as draft, even though it is fully functional.