### PR TITLE
Temp Waybar14 wildcard fix

### DIFF
--- a/config.jsonc
+++ b/config.jsonc
@@ -148,7 +148,7 @@
 		// "rotate":
 		"min-length": 2,
 		"max-length": 2,
-		"on-click": "ghostty -e ~/.config/waybar/scripts/bluetooth.sh",
+		"on-click": "kitty -e ~/.config/waybar/scripts/bluetooth.sh",
 		// "on-click-middle":
 		"on-click-right": "bluetoothctl power off && notify-send 'Bluetooth Off' -r 1925",
 		// "on-scroll-up":
@@ -335,7 +335,7 @@
 		// "rotate":
 		"min-length": 2,
 		"max-length": 2,
-		"on-click": "ghostty -e ~/.config/waybar/scripts/network.sh",
+		"on-click": "kitty -e ~/.config/waybar/scripts/network.sh",
 		// "on-click-middle":
 		"on-click-right": "nmcli radio wifi off && notify-send 'Wi-Fi Disabled' -r 1125",
 		// "on-scroll-up":
@@ -448,7 +448,7 @@
 		"format": "{}",
 		"rewrite": {
 			"^$": "Desktop",
-			"^ghostty$": "Terminal",
+			"^kitty$": "Terminal",
 			"^zsh$": "Terminal",
 			"^~$": "Terminal"
 		},
@@ -643,7 +643,7 @@
 
 	"custom/power_menu": {
 		"format": "󰤄",
-		"on-click": "ghostty -e ~/.config/waybar/scripts/power-menu.sh",
+		"on-click": "kitty -e ~/.config/waybar/scripts/power-menu.sh",
 		"tooltip": false
 	},
 
@@ -661,7 +661,7 @@
 		// "rotate":
 		"min-length": 2,
 		"max-length": 2,
-		"on-click": "ghostty -e ~/.config/waybar/scripts/system-update.sh start"
+		"on-click": "kitty -e ~/.config/waybar/scripts/system-update.sh start"
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-scroll-up":

--- a/config.jsonc
+++ b/config.jsonc
@@ -1,13 +1,4 @@
 {
-	"include": [
-		"~/.config/waybar/modules/*.jsonc",
-		"~/.config/waybar/modules/custom/*.jsonc",
-		"~/.config/waybar/modules/hyprland/*.jsonc",
-
-		// modules that are not included by default:
-		"~/.config/waybar/modules/extras/*.jsonc"
-	],
-
 	/*------------
 		layout
 	------------*/
@@ -78,5 +69,606 @@
 	// "passthrough":
 	// "ipc":
 	// "id":
-	"reload_style_on_change": true
+	"reload_style_on_change": true,
+
+	/*-------------
+		modules
+	-------------*/
+
+	"backlight": {
+		// "interval":
+		"format": "{icon} {percent}%",
+		"format-icons": [
+			"", "", "", "", "", "", "", "", ""
+		],
+		"min-length": 7,
+		"max-length": 7,
+		// "rotate":
+		// "states":
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		"on-scroll-up": "~/.config/waybar/scripts/backlight.sh up",
+		"on-scroll-down": "~/.config/waybar/scripts/backlight.sh down",
+		// "smooth-scrolling-threshold":
+		// "reverse-scrolling":
+		// "reverse-mouse-scrolling":
+		// "scroll-step":
+		"tooltip": false
+		// "tooltip-format":
+	},
+
+	"battery": {
+		// "bat":
+		// "adapter":
+		// "design-capacity":
+		// "full-at":
+		// "interval":
+		"states": {
+			"warning": 20,
+			"critical": 10
+		},
+		"format": "{icon} {capacity}%",
+		"format-time": "{H} hr {M} min",
+		"format-icons": [
+			"󰂎", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"
+		],
+		"format-charging": "󰉁 {capacity}%",
+		"min-length": 7,
+		"max-length": 7,
+		// "rotate":
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Discharging: {time}",
+		"tooltip-format-charging": "Charging: {time}",
+		// "weighted-average":
+		// "bat-compatibility":
+		"events": {
+			"on-discharging-warning": "notify-send 'Low Battery' '{capacity}% battery remaining'",
+			"on-discharging-critical": "notify-send 'Low Battery' '{capacity}% battery remaining' -u critical",
+			"on-charging-100": "notify-send 'Battery full' 'Battery is at {capacity}%'"
+		}
+	},
+
+	"bluetooth": {
+		// "controller":
+		// "format-device-preference":
+		"format": "󰂯",
+		"format-disabled": "󰂲",
+		"format-off": "󰂲",
+		"format-on": "󰂰",
+		"format-connected": "󰂱",
+		// "format-connected-battery":
+		// "format-no-controller":
+		// "rotate":
+		"min-length": 2,
+		"max-length": 2,
+		"on-click": "ghostty -e ~/.config/waybar/scripts/bluetooth.sh",
+		// "on-click-middle":
+		"on-click-right": "bluetoothctl power off && notify-send 'Bluetooth Off' -r 1925",
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Device Addr: {device_address}",
+		"tooltip-format-disabled": "Bluetooth Disabled",
+		"tooltip-format-off": "Bluetooth Off",
+		"tooltip-format-on": "Bluetooth Disconnected",
+		"tooltip-format-connected": "Device: {device_alias}",
+		"tooltip-format-enumerate-connected": "Device: {device_alias}",
+		"tooltip-format-connected-battery": "Device: {device_alias}\nBattery: {device_battery_percentage}%",
+		"tooltip-format-enumerate-connected-battery": "Device: {device_alias}\nBattery: {device_battery_percentage}%"
+	},
+
+	"clock#time": {
+		// "interval":
+		"format": "{:%H:%M}",
+		// "timezone":
+		// "timezones":
+		// "locale":
+		"min-length": 5,
+		"max-length": 5,
+		// "rotate": 0,
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Standard Time: {:%I:%M %p}"
+	},
+
+	/*--------------
+		calendar
+	--------------*/
+
+	"clock#date": {
+		// "interval":
+		"format": "󰸗 {:%m-%d}",
+		// "timezone":
+		// "timezones":
+		// "locale":
+		"min-length": 8,
+		"max-length": 8,
+		// "rotate":
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "{calendar}",
+		"calendar": {
+			"mode": "month",
+			"mode-mon-col": 6,
+			// "week-pos":
+			// "on-scroll":
+			"format": {
+				"months": "<span alpha='100%'><b>{}</b></span>",
+				"days": "<span alpha='90%'>{}</span>",
+				// "weeks":
+				"weekdays": "<span alpha='80%'><i>{}</i></span>",
+				"today": "<span alpha='100%'><b><u>{}</u></b></span>"
+			}
+		},
+		"actions": {
+			"on-click": "mode"
+			// "on-click-middle":
+			// "on-click-right":
+			// "on-scroll-up":
+			// "on-scroll-down":
+		}
+	},
+
+	"cpu": {
+		"interval": 10,
+		"format": "󰍛 {usage}%",
+		"format-warning": "󰀨 {usage}%",
+		"format-critical": "󰀨 {usage}%",
+		"min-length": 7,
+		"max-length": 7,
+		// "rotate":
+		"states": {
+			"warning": 75,
+			"critical": 90
+		},
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		"tooltip": false
+	},
+
+	"idle_inhibitor": {
+		"format": "{icon}",
+		"format-icons": {
+			"activated": "󰈈",
+			"deactivated": "󰈉"
+		},
+		// "rotate":
+		"min-length": 3,
+		"max-length": 3,
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format-activated": "Presentation Mode (<span text_transform='capitalize'>{status}</span>)",
+		"tooltip-format-deactivated": "Idle Mode (<span text_transform='capitalize'>{status}</span>)",
+		"start-activated": false
+		// "timeout":
+	},
+
+	"memory": {
+		"interval": 10,
+		"format": "󰘚 {percentage}%",
+		"format-warning": "󰀧 {percentage}%",
+		"format-critical": "󰀧 {percentage}%",
+		// "rotate":
+		"states": {
+			"warning": 75,
+			"critical": 90
+		},
+		"min-length": 7,
+		"max-length": 7,
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Memory Used: {used:0.1f} GB / {total:0.1f} GB"
+	},
+
+	"mpris": {
+		// "player":
+		// "ignored-players":
+		// "interval":
+		"format": "{player_icon} {title} - {artist}",
+		"format-paused": "{status_icon} {title} - {artist}",
+		"tooltip-format": "Playing: {title} - {artist}",
+		"tooltip-format-paused": "Paused: {title} - {artist}",
+		// "enable-tooltip-len-limits":
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		"player-icons": {
+			"default": "󰐊"
+		},
+		"status-icons": {
+			"paused": "󰏤"
+		},
+		// "dynamic-order":
+		// "dynamic-len":
+		// "dynamic-separator":
+		// "dynamic-importance-order":
+		// "min-length":
+		"max-length": 1000
+	},
+
+	"network": {
+		// "interface":
+		"interval": 10,
+		// "family":
+		"format": "󰤨",
+		"format-ethernet": "󰈀",
+		"format-wifi": "{icon}",
+		// "format-linked":
+		"format-disconnected": "󰤯",
+		"format-disabled": "󰤮",
+		// "format-alt":
+		"format-icons": [
+			"󰤟", "󰤢", "󰤥", "󰤨"
+		],
+		// "rotate":
+		"min-length": 2,
+		"max-length": 2,
+		"on-click": "ghostty -e ~/.config/waybar/scripts/network.sh",
+		// "on-click-middle":
+		"on-click-right": "nmcli radio wifi off && notify-send 'Wi-Fi Disabled' -r 1125",
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Gateway: {gwaddr}",
+		"tooltip-format-ethernet": "Interface: {ifname}",
+		"tooltip-format-wifi": "Network: {essid}\nIP Addr: {ipaddr}/{cidr}\nStrength: {signalStrength}%\nFrequency: {frequency} GHz",
+		"tooltip-format-disconnected": "Wi-Fi Disconnected",
+		"tooltip-format-disabled": "Wi-Fi Disabled"
+	},
+
+	"group/pulseaudio": {
+		"orientation": "horizontal",
+		"modules": [
+			"pulseaudio#output",
+			"pulseaudio#input"
+		],
+		"drawer": {
+			// "transition-duration":
+			"transition-left-to-right": false
+			// "children-class":
+			// "click-to-reveal":
+		}
+	},
+
+	"pulseaudio#output": {
+		"format": "{icon} {volume}%",
+		// "format-bluetooth":
+		"format-muted": "󰝟 {volume}%",
+		// "format-source":
+		// "format-source-muted":
+		"format-icons": {
+			"default": [ "󰕿", "󰖀", "󰕾" ],
+			"headphone": "󰋋",
+			"headset": "󰋋"
+		},
+		// "rotate":
+		// "states":
+		"min-length": 7,
+		"max-length": 7,
+		// "scroll-step":
+		"on-click": "~/.config/waybar/scripts/volume.sh output mute",
+		// "on-click-middle":
+		// "on-click-right":
+		"on-scroll-up": "~/.config/waybar/scripts/volume.sh output raise",
+		"on-scroll-down": "~/.config/waybar/scripts/volume.sh output lower",
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Output Device: {desc}"
+		// "max-volume":
+		// "ignored-sinks":
+		// "reverse-scrolling":
+		// "reverse-mouse-scrolling":
+	},
+
+	"pulseaudio#input": {
+		"format": "{format_source}",
+		// "format-bluetooth":
+		// "format-muted":
+		"format-source": "󰍬 {volume}%",
+		"format-source-muted": "󰍭 {volume}%",
+		// "format-icons":
+		// "rotate":
+		// "states":
+		"min-length": 7,
+		"max-length": 7,
+		// "scroll-step":
+		"on-click": "~/.config/waybar/scripts/volume.sh input mute",
+		// "on-click-middle":
+		// "on-click-right":
+		"on-scroll-up": "~/.config/waybar/scripts/volume.sh input raise",
+		"on-scroll-down": "~/.config/waybar/scripts/volume.sh input lower",
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Input Device: {desc}"
+		// "max-volume":
+		// "ignored-sinks":
+		// "reverse-scrolling":
+		// "reverse-mouse-scrolling":
+	},
+
+	"temperature": {
+		"thermal-zone": 1,
+		// "hwmon-path":
+		// "hwmon-path-abs":
+		// "input-filename":
+		"critical-threshold": 90,
+		"interval": 10,
+		"format-critical": "󰀦 {temperatureC}°C",
+		"format": "{icon} {temperatureC}°C",
+		"format-icons": [
+			"󱃃", "󰔏", "󱃂"
+		],
+		// "rotate":
+		"min-length": 8,
+		"max-length": 8,
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		"tooltip-format": "Temp in Fahrenheit: {temperatureF}°F"
+	},
+
+	"hyprland/window": {
+		"format": "{}",
+		"rewrite": {
+			"^$": "Desktop",
+			"^ghostty$": "Terminal",
+			"^zsh$": "Terminal",
+			"^~$": "Terminal"
+		},
+		// "separate-outputs":
+		// "icon":
+		// "icon-size":
+		// "min-length":
+		// "max-length":
+		"tooltip": false,
+		"swap-icon-label": false
+	},
+
+	"hyprland/windowcount": {
+		"format": "[{}]",
+		// "format-empty":
+		// "format-windowed":
+		// "format-fullscreen":
+		// "separate-outputs":
+		// "min-length":
+		// "max-length":
+		"swap-icon-label": false
+	},
+
+	"hyprland/workspaces": {
+		// "active-only":
+		// "hide-active":
+		// "all-outputs":
+		"format": "{icon}",
+		"format-icons": {
+			"active": "",
+			"default": ""
+		},
+		"persistent-workspaces": {
+			"*": 5
+		},
+		// "persistent-only":
+		// "show-special":
+		// "special-visible-only":
+		// "sort-by":
+		// "window-rewrite":
+		// "window-rewrite-default":
+		// "format-window-separator":
+		// "move-to-monitor":
+		// "ignore-workspaces":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		"cursor": true
+	},
+
+	"group/theme_switcher": {
+		"orientation": "horizontal",
+		"modules": [
+			"custom/theme_switcher",
+			"custom/user"
+		],
+		"drawer": {
+			// "transition-duration":
+			// "transition-left-to-right":
+			// "children-class":
+			// "click-to-reveal":
+		}
+	},
+
+	"custom/theme_switcher": {
+		"exec": "~/.config/waybar/scripts/theme-switcher.sh",
+		// "exec-if":
+		// "exec-on-event":
+		// "hide-empty-text":
+		"return-type": "json",
+		// "interval":
+		// "restart-interval":
+		// "signal":
+		"format": "{}",
+		// "format-icons":
+		// "rotate":
+		"min-length": 4,
+		"max-length": 4,
+		"on-click": "~/.config/waybar/scripts/theme-switcher.sh next",
+		// "on-click-middle":
+		"on-click-right": "~/.config/waybar/scripts/theme-switcher.sh prev"
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		// "tooltip-format":
+		// "escape":
+	},
+
+	"custom/user": {
+		"exec": "id --user --name",
+		// "exec-if":
+		// "exec-on-event":
+		// "hide-empty-text":
+		// "return-type":
+		// "interval":
+		// "restart-interval":
+		// "signal":
+		"format": "{}",
+		// "format-icons":
+		// "rotate":
+		// "min-length":
+		// "max-length":
+		// "on-click":
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		"tooltip": false
+		// "tooltip-format":
+		// "escape":
+	},
+
+	"custom/distro": {
+		"format": "󰣇",
+		"tooltip": false
+	},
+
+	/*-------------------
+		left dividers
+	-------------------*/
+
+	"custom/left_div#1": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_div#2": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_div#3": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_div#4": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_div#5": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_div#6": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_div#7": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_div#8": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_inv#1": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/left_inv#2": {
+		"format": "",
+		"tooltip": false
+	},
+
+	/*--------------------
+		right dividers
+	--------------------*/
+
+	"custom/right_div#1": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/right_div#2": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/right_div#3": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/right_div#4": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/right_div#5": {
+		"format": "",
+		"tooltip": false
+	},
+	"custom/right_inv#1": {
+		"format": "",
+		"tooltip": false
+	},
+
+	"custom/power_menu": {
+		"format": "󰤄",
+		"on-click": "ghostty -e ~/.config/waybar/scripts/power-menu.sh",
+		"tooltip": false
+	},
+
+	"custom/system_update": {
+		"exec": "~/.config/waybar/scripts/system-update.sh",
+		// "exec-if":
+		// "exec-on-event":
+		// "hide-empty-text":
+		"return-type": "json",
+		"interval": 3600,
+		// "restart-interval":
+		// "signal":
+		"format": "{}",
+		// "format-icons":
+		// "rotate":
+		"min-length": 2,
+		"max-length": 2,
+		"on-click": "ghostty -e ~/.config/waybar/scripts/system-update.sh start"
+		// "on-click-middle":
+		// "on-click-right":
+		// "on-scroll-up":
+		// "on-scroll-down":
+		// "smooth-scrolling-threshold":
+		// "tooltip":
+		// "tooltip-format":
+		// "escape":
+	}
 }


### PR DESCRIPTION
On brand new arch setup, didn't want to downgrade to waybar13, so i grepped all the modules i found and put them into a single file without wildcards.

Here's how it looks like now:

<img width="2555" height="256" alt="image" src="https://github.com/user-attachments/assets/b9c57a37-43f8-48b7-9a42-04f78d02e3fe" />