### PR TITLE
Restart Waybar using its systemd service if it's enabled

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,12 +48,11 @@ main() {
 	cprintf blue "\nRestarting Waybar..."
 
 	if ! (systemctl --user is-enabled waybar.service &&
-		systemctl --user restart waybar.service) &>/dev/null; then
-    	pkill waybar
-    	waybar &>/dev/null &
-    	disown
+		systemctl --user restart waybar.service) &> /dev/null; then
+		pkill waybar
+		waybar &> /dev/null &
+		disown
 	fi
-
 
 	if ((ERRORS > 0)); then
 		cprintf red "\nInstallation completed with $ERRORS errors"


### PR DESCRIPTION
For uwsm users, Hyprland [recommends](https://wiki.hypr.land/Useful-Utilities/Status-Bars/#how-to-launch) enabling Waybar via its Systemd service. The script will now check if the user is running Waybar using the Systemd service or not, if the service is not enabled, the script will restart Waybar like usual.