### PR TITLE
Improvements to system-update.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,30 @@ Feel free to open a pull request to add new themes! :^)
 > + "on-click": "ghostty -e ..."
 > ```
 
+<details>
+<summary>System Update</summary>
+
+The system update module requires `notify-send` (libnotify) and optionally an
+AUR helper for checking AUR packages.
+
+| Helper        | Check Official | Check AUR | Update Both |
+| :------------ | :------------: | :-------: | :--------: |
+| **aura**      | ✓              | ✓         | ✓          |
+| **paru**      | ✓              | ✓         | ✓          |
+| **pikaur**    | ✓              | ✓         | ✓          |
+| **trizen**    | ✓              | ✓         | ✓          |
+| **yay**       | ✓              | ✓         | ✓          |
+
+If an AUR helper is installed, it will be used for all update checking and
+upgrading (official repos and AUR).
+
+If **no AUR helper** is installed:
+- Only official Arch repositories can be checked/updated
+- `checkupdates` (from `pacman-contrib`) is required
+- AUR packages will not be checked or updated
+
+</details>
+
 #
 
 ### Installation

--- a/scripts/system-update.sh
+++ b/scripts/system-update.sh
@@ -13,6 +13,8 @@
 # Date:    August 16, 2025
 # License: MIT
 
+set -o pipefail
+
 FG_GREEN="\e[32m"
 FG_BLUE="\e[34m"
 FG_RESET="\e[39m"
@@ -20,6 +22,7 @@ FG_RESET="\e[39m"
 FAILURE=false
 PAC_UPD=0
 AUR_UPD=0
+HELPER=
 
 TIMEOUT=10
 HELPERS=(aura paru pikaur trizen yay)
@@ -38,10 +41,32 @@ get_helper() {
 	done
 }
 
+reset_state() {
+	FAILURE=false
+	PAC_UPD=0
+	AUR_UPD=0
+}
+
+get_ignored_pkgs() {
+	grep -E "^IgnorePkg" /etc/pacman.conf | sed 's/IgnorePkg = //' | tr ' ' '\n' | grep -v '^$'
+}
+
+filter_ignored() {
+	local ignored
+	ignored=$(get_ignored_pkgs)
+	if [[ -z $ignored ]]; then
+		cat
+	else
+		grep -v -F -f <(echo "$ignored") || true
+	fi
+}
+
 check_updates() {
+	reset_state
+
 	if [[ -n $HELPER ]]; then
 		local pac_output pac_status
-		pac_output=$(timeout $TIMEOUT "$HELPER" -Qud)
+		pac_output=$(timeout $TIMEOUT "$HELPER" -Qud | filter_ignored)
 		pac_status=$?
 
 		if ((pac_status != 0 && pac_status != 2)); then
@@ -51,7 +76,7 @@ check_updates() {
 		PAC_UPD=$(grep -c . <<< "$pac_output")
 
 		local aur_output aur_status
-		aur_output=$(timeout $TIMEOUT "$HELPER" -Qua)
+		aur_output=$(timeout $TIMEOUT "$HELPER" -Qua | filter_ignored)
 		aur_status=$?
 
 		if ((${#aur_output} > 0 && aur_status != 0)); then
@@ -61,7 +86,7 @@ check_updates() {
 		AUR_UPD=$(grep -c . <<< "$aur_output")
 	else
 		local pac_output pac_status
-		pac_output=$(timeout $TIMEOUT checkupdates)
+		pac_output=$(timeout $TIMEOUT checkupdates | filter_ignored)
 		pac_status=$?
 
 		if ((pac_status != 0 && pac_status != 2)); then

--- a/scripts/system-update.sh
+++ b/scripts/system-update.sh
@@ -5,9 +5,9 @@
 # Waybar
 #
 # Requirements:
-# - checkupdates (pacman-contrib)
 # - notify-send (libnotify)
-# - Optional: An AUR helper
+# - checkupdates (pacman-contrib) — only needed if no AUR helper is installed
+# - AUR helper (optional) — aura, paru, pikaur, trizen, or yay
 #
 # Author:  Jesse Mirabel <sejjymvm@gmail.com>
 # Date:    August 16, 2025
@@ -39,42 +39,47 @@ get_helper() {
 }
 
 check_updates() {
-	local pac_output pac_status
+	if [[ -n $HELPER ]]; then
+		local pac_output pac_status
+		pac_output=$(timeout $TIMEOUT "$HELPER" -Qud)
+		pac_status=$?
 
-	pac_output=$(timeout $TIMEOUT checkupdates)
-	pac_status=$?
+		if ((pac_status != 0 && pac_status != 2)); then
+			FAILURE=true
+			return 1
+		fi
+		PAC_UPD=$(grep -c . <<< "$pac_output")
 
-	if ((pac_status != 0 && pac_status != 2)); then
-		FAILURE=true
-		return 1
+		local aur_output aur_status
+		aur_output=$(timeout $TIMEOUT "$HELPER" -Qua)
+		aur_status=$?
+
+		if ((${#aur_output} > 0 && aur_status != 0)); then
+			FAILURE=true
+			return 1
+		fi
+		AUR_UPD=$(grep -c . <<< "$aur_output")
+	else
+		local pac_output pac_status
+		pac_output=$(timeout $TIMEOUT checkupdates)
+		pac_status=$?
+
+		if ((pac_status != 0 && pac_status != 2)); then
+			FAILURE=true
+			return 1
+		fi
+		PAC_UPD=$(grep -c . <<< "$pac_output")
+		AUR_UPD=0
 	fi
-
-	PAC_UPD=$(grep -c . <<< "$pac_output")
-
-	if [[ -z $HELPER ]]; then
-		return 0
-	fi
-
-	local aur_output aur_status
-
-	aur_output=$(timeout $TIMEOUT "$HELPER" -Quaq)
-	aur_status=$?
-
-	if ((${#aur_output} > 0 && aur_status != 0)); then
-		FAILURE=true
-		return 1
-	fi
-
-	AUR_UPD=$(grep -c . <<< "$aur_output")
 }
 
 update_packages() {
-	printf "%bUpdating pacman packages...%b\n" "$FG_BLUE" "$FG_RESET"
-	sudo pacman -Syu
-
 	if [[ -n $HELPER ]]; then
-		printf "\n%bUpdating AUR packages...%b\n" "$FG_BLUE" "$FG_RESET"
+		printf "%bUpdating packages ($HELPER)...%b\n" "$FG_BLUE" "$FG_RESET"
 		command "$HELPER" -Syu
+	else
+		printf "%bUpdating packages (pacman)...%b\n" "$FG_BLUE" "$FG_RESET"
+		sudo pacman -Syu
 	fi
 
 	notify-send "Update Complete" -i "package-install"


### PR DESCRIPTION
Hello, 

This fix contains two improvements :

1. Removed the dependency call to `checkupdates` if you are using a helper (paru, etc.). (Install script not modified though)
2. Filter the updates concerning an package which version is pinned (using downgrade cmd: https://archlinux-downgrade.github.io/downgrade/)

