### PR TITLE
fix(scripts/update): move EXIT trap to interactive branch only

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -102,9 +102,6 @@ display_module() {
 }
 
 main() {
-	# Update the module on exit
-	trap "pkill -RTMIN+1 waybar" EXIT
-
 	FAILED=false
 	UPDATES=0
 	AUR_UPDATES=0
@@ -117,6 +114,9 @@ main() {
 			display_module
 			;;
 		*)
+			# Update the module on exit
+			trap "pkill -RTMIN+1 waybar" EXIT
+
 			printf "%bChecking for updates...%b\n" "$FG_BLUE" "$FG_RESET"
 
 			check_updates


### PR DESCRIPTION
The `trap "pkill -RTMIN+1 waybar" EXIT` was placed at the top of `main()`, so it fired in both the background module check and the interactive update case. Every time waybar ran `update module`, the script would exit, the trap would immediately re signal waybar to run the module again, and the cycle would repeat forever, bypassing the configured interval.  This causes checkupdates and the AUR helper to run in a loop, making lots of requests to Arch mirrors and triggering HTTP 429 responses. 
Fix: move the trap inside the `*)` case only, so it triggers only after an interactive update.

How to verify the fix

Before: running `watch -n 1 pgrep -a checkupdates` shows the process spawning continuously.
After: the process only appears on the configured interval or when the module is manually triggered via signal.