### PR TITLE
Added a feature so right clicking an audio icon pops up the audio mixer

### DIFF
--- a/modules/cpu.jsonc
+++ b/modules/cpu.jsonc
@@ -14,7 +14,7 @@
 			"warning": 75,
 			"critical": 90
 		},
-		// "on-click":
+		"on-click": "kitty -e ~/.config/waybar/scripts/btop-gui",
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":

--- a/modules/memory.jsonc
+++ b/modules/memory.jsonc
@@ -14,7 +14,7 @@
 		"max-length": 7,
 		// "align":
 		// "justify":
-		// "on-click":
+		"on-click": "kitty -e ~/.config/waybar/scripts/btop-gui",
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":

--- a/modules/pulseaudio.jsonc
+++ b/modules/pulseaudio.jsonc
@@ -40,7 +40,7 @@
 		// "scroll-step":
 		"on-click": "~/.config/waybar/scripts/volume output mute",
 		// "on-click-middle":
-		// "on-click-right":
+		"on-click-right": "kitty -e ~/.config/waybar/scripts/volume-gui output",
 		// "on-update":
 		"on-scroll-up": "~/.config/waybar/scripts/volume output raise",
 		"on-scroll-down": "~/.config/waybar/scripts/volume output lower",
@@ -77,7 +77,7 @@
 		// "scroll-step":
 		"on-click": "~/.config/waybar/scripts/volume input mute",
 		// "on-click-middle":
-		// "on-click-right":
+		"on-click-right": "kitty -e ~/.config/waybar/scripts/volume-gui input",
 		// "on-update":
 		"on-scroll-up": "~/.config/waybar/scripts/volume input raise",
 		"on-scroll-down": "~/.config/waybar/scripts/volume input lower",

--- a/scripts/btop-gui
+++ b/scripts/btop-gui
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Launch btop system monitor if available
+#
+
+main() {
+    if command -v btop &>/dev/null; then
+        btop
+    fi
+}
+
+main "$@"

--- a/scripts/volume-gui
+++ b/scripts/volume-gui
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Open audio GUI control
+# Tries wiremix first, falls back to pavucontrol
+#
+
+main() {
+    local tab=$1
+    if command -v wiremix &>/dev/null; then
+        wiremix --tab "$tab"
+    elif command -v pavucontrol &>/dev/null; then
+        pavucontrol
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
When right clicking an audio icon in machabar, either `wiremix` or `pavucontrol` is launched.
This is super convenient to rapidly access the audio mixer straight from the bar.
 
I've chosen `wiremix` as the default app to remain consistent with the TUI spirit from bluetooth & other icons's behaviors.

Current behavior is untouched: when clicking an icon, this will turn either input or output off though I'd say the opposite makes more sense to the user:

- left click => mixer
- right click => mute

and is more consistent with other icons such as bluetooth where right click turns the protocol off.