### PR TITLE
fix(scripts/styles): improve waybar for omarchy users

### DIFF
--- a/modules/backlight.jsonc
+++ b/modules/backlight.jsonc
@@ -2,9 +2,7 @@
 	"backlight": {
 		// "interval":
 		"format": "{icon} {percent}%",
-		"format-icons": [
-			"", "", "", "", "", "", "", "", ""
-		],
+		"format-icons": ["󰃞", "󰃟", "󰃠"],
 		"min-length": 7,
 		"max-length": 7,
 		// "align":

--- a/modules/battery.jsonc
+++ b/modules/battery.jsonc
@@ -20,7 +20,7 @@
 		// "align":
 		// "justify":
 		// "rotate":
-		// "on-click":
+		"on-click": "omarchy-menu power",
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":

--- a/modules/bluetooth.jsonc
+++ b/modules/bluetooth.jsonc
@@ -15,9 +15,9 @@
 		"max-length": 2,
 		// "align":
 		// "justify":
-		"on-click": "kitty -e ~/.config/waybar/scripts/bluetooth",
+		"on-click": "omarchy-launch-bluetooth",
 		// "on-click-middle":
-		"on-click-right": "~/.config/waybar/scripts/bluetooth off",
+		// "on-click-right",
 		// "on-scroll-up":
 		// "on-scroll-down":
 		// "smooth-scrolling-threshold":

--- a/modules/cpu.jsonc
+++ b/modules/cpu.jsonc
@@ -14,7 +14,7 @@
 			"warning": 75,
 			"critical": 90
 		},
-		// "on-click":
+		"on-click": "omarchy-launch-or-focus-tui btop",
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":

--- a/modules/custom/power.jsonc
+++ b/modules/custom/power.jsonc
@@ -15,7 +15,7 @@
 		// "max-length":
 		// "align":
 		// "justify":
-		"on-click": "kitty -e ~/.config/waybar/scripts/power",
+		"on-click": "omarchy-menu system",
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":

--- a/modules/custom/update.jsonc
+++ b/modules/custom/update.jsonc
@@ -15,7 +15,7 @@
 		// "justify":
 		"min-length": 2,
 		"max-length": 2,
-		"on-click": "kitty -e ~/.config/waybar/scripts/update",
+		"on-click": "~/.config/waybar/scripts/update",
 		// "on-click-middle":
 		"on-click-right": "pkill -RTMIN+1 waybar"
 		// "on-update":

--- a/modules/custom/user.jsonc
+++ b/modules/custom/user.jsonc
@@ -15,7 +15,7 @@
 		"max-length": 4,
 		// "align":
 		// "justify":
-		// "on-click":
+		"on-click": "omarchy-menu",
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":

--- a/modules/hyprland/language.jsonc
+++ b/modules/hyprland/language.jsonc
@@ -2,7 +2,8 @@
 	"hyprland/language": {
 		// "format":
 		// "format-<lang>":
-		"format-en": " en"
+        "format": "󰌌 {}",
+        "keyboard-name": "at-translated-set-2-keyboard",
 		// "keyboard-name":
 		// "min-length":
 		// "max-length":

--- a/modules/hyprland/window.jsonc
+++ b/modules/hyprland/window.jsonc
@@ -5,6 +5,7 @@
 			"": "Desktop",
 			"kitty": "Terminal",
 			"zsh": "Terminal",
+            "ghostty" : "Terminal",
 			"~": "Terminal"
 		},
 		// "separate-outputs":

--- a/modules/idle_inhibitor.jsonc
+++ b/modules/idle_inhibitor.jsonc
@@ -10,7 +10,7 @@
 		"max-length": 3,
 		// "align":
 		// "justify":
-		// "on-click":
+		"on-click": "omarchy-toggle-idle",
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":

--- a/modules/memory.jsonc
+++ b/modules/memory.jsonc
@@ -1,7 +1,7 @@
 {
 	"memory": {
 		"interval": 10,
-		"format": "󰘚 {percentage}%",
+		"format": "  {percentage}%",
 		"format-warning": "󰀧 {percentage}%",
 		"format-critical": "󰀧 {percentage}%",
 		// "format-icons":

--- a/modules/network.jsonc
+++ b/modules/network.jsonc
@@ -19,9 +19,9 @@
 		"max-length": 2,
 		// "align":
 		// "justify":
-		"on-click": "kitty -e ~/.config/waybar/scripts/network",
+		"on-click": "omarchy-launch-wifi",
 		// "on-click-middle":
-		"on-click-right": "~/.config/waybar/scripts/network off",
+		// "on-click-right":,
 		// "on-update":
 		// "on-scroll-up":
 		// "on-scroll-down":

--- a/modules/pulseaudio.jsonc
+++ b/modules/pulseaudio.jsonc
@@ -42,8 +42,8 @@
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":
-		"on-scroll-up": "~/.config/waybar/scripts/volume output raise",
-		"on-scroll-down": "~/.config/waybar/scripts/volume output lower",
+		"on-scroll-up": "~/.config/waybar/scripts/volume output raise 5",
+		"on-scroll-down": "~/.config/waybar/scripts/volume output lower 5",
 		// "smooth-scrolling-threshold":
 		// "tooltip":
 		"tooltip-format": "<b>Output Device</b>: {desc}"
@@ -79,8 +79,8 @@
 		// "on-click-middle":
 		// "on-click-right":
 		// "on-update":
-		"on-scroll-up": "~/.config/waybar/scripts/volume input raise",
-		"on-scroll-down": "~/.config/waybar/scripts/volume input lower",
+		"on-scroll-up": "~/.config/waybar/scripts/volume input raise 5",
+		"on-scroll-down": "~/.config/waybar/scripts/volume input lower 5",
 		// "smooth-scrolling-threshold":
 		// "tooltip":
 		"tooltip-format": "<b>Input Device</b>: {desc}"

--- a/modules/temperature.jsonc
+++ b/modules/temperature.jsonc
@@ -1,8 +1,14 @@
 {
 	"temperature": {
 		"thermal-zone": 1,
-		// "hwmon-path":
-		// "hwmon-path-abs":
+        "hwmon-path": [
+            "/sys/class/hwmon/hwmon0/temp1_input",
+            "/sys/class/hwmon/hwmon1/temp1_input",
+            "/sys/class/hwmon/hwmon2/temp1_input",
+            "/sys/class/hwmon/hwmon3/temp1_input",
+            "/sys/class/hwmon/hwmon4/temp1_input",
+            "/sys/class/hwmon/hwmon5/temp1_input"
+        ],
 		// "input-filename":
 		// "warning-threshold":
 		"critical-threshold": 90,

--- a/style.css
+++ b/style.css
@@ -12,21 +12,21 @@
 @import "styles/states.css";
 
 .module {
-	margin-bottom: -1px;
+	margin-bottom: 2px;
 }
 
 #waybar {
 	background-color: @outline;
 }
 #waybar > box {
-	margin: 4px;
+	margin: 2px;
 	background-color: @main-bg;
 }
 
 button {
-	border-radius: 16px;
-	min-width: 16px;
-	padding: 0 10px;
+	border-radius: 14px;
+	min-width: 5px;
+	padding: 0 8px;
 }
 button:hover {
 	background-color: @hover-bg;
@@ -34,10 +34,10 @@ button:hover {
 }
 
 tooltip {
-	border: 2px solid @main-br;
+	border: 1px solid @main-br;
 	border-radius: 10px;
 	background-color: @main-bg;
 }
 tooltip > box {
-	padding: 0 6px;
+	padding: 0 5px;
 }

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,28 +1,28 @@
 * {
-	font-family: "CommitMono Nerd Font";
-	font-weight: bold;
-	font-size: 16px;
+    font-family: "JetBrainsMono Nerd Font";
+    font-weight: bold;
+    font-size: 12px;
 }
 
 #window label,
 #mpris,
 tooltip label {
-	font-weight: normal;
+    font-weight: normal;
 }
 
 #workspaces button.active label,
 #workspaces button.focused label,
 #custom-distro {
-	font-size: 20px;
+    font-size: 12px;
 }
 
 #custom-power {
-	font-size: 18px;
+    font-size: 12px;
 }
 
 #custom-left_div,
 #custom-left_inv,
 #custom-right_div,
 #custom-right_inv {
-	font-size: 22px;
+    font-size: 13px;
 }

--- a/styles/modules-center.css
+++ b/styles/modules-center.css
@@ -4,7 +4,8 @@
 
 #keyboard-state label,
 #language {
-	margin-right: 12px;
+	margin-right: 8px;
+    margin-left: 8px;
 	color: @hover-fg;
 }
 
@@ -103,15 +104,15 @@
 
 #network {
 	background-color: @tray;
-	padding: 0 6px 0 4px;
+	padding: 0 6px 0 2px;
 }
 #bluetooth {
 	background-color: @tray;
-	padding: 0 5px;
+	padding: 0 2px;
 }
 #custom-update {
 	background-color: @tray;
-	padding: 0 8px 0 2px;
+	padding: 0 6px 0 2px;
 }
 #custom-right_div.5 {
 	color: @tray;

--- a/styles/modules-left.css
+++ b/styles/modules-left.css
@@ -7,7 +7,7 @@
 	color: @workspaces;
 }
 #workspaces {
-	padding: 0 1px;
+	padding: 0 2px;
 	background-color: @workspaces;
 }
 #workspaces button.active label,
@@ -20,5 +20,5 @@
 ------------------*/
 
 #window {
-	margin: 0 12px;
+	margin: 0 5px;
 }

--- a/styles/modules-right.css
+++ b/styles/modules-right.css
@@ -51,7 +51,7 @@
 
 #custom-power {
 	border-radius: 16px;
-	padding: 0 19px 0 16px;
+	padding: 0 12px 0 12px;
 	color: @accent;
 }
 #custom-power:hover {


### PR DESCRIPTION
- Create a new branch for the omarchy config
- Fix the temperature module tracking by mapping multiple `hwmon` paths (`/sys/class/hwmon/hwmon[0-5]`)
- Change the backlight format icons
- Add a battery on-click event to trigger `omarchy-menu power`
- Change Bluetooth on-click event to trigger `omarchy-launch-bluetooth`
- Change CPU on-click event to trigger `omarchy-launch-or-focus-tui btop`
- Replace direct `kitty` terminal executions with native Omarchy scripts across modules (`omarchy-menu system`, `omarchy-toggle-idle`, `omarchy-launch-wifi`)
- Add `ghostty` terminal recognition to the Hyprland window module
- Update pulseaudio scroll settings to adjust volume in increments of 5%
- Update the language module format to include a keyboard icon and explicitly set the `keyboard-name`
- Update the memory module icon to a memory chip
- Overhaul global CSS for a more compact layout, reducing margins, paddings, and border-radii
- Switch global typography to `JetBrainsMono Nerd Font` and reduce base font sizes to 12px