### PR TITLE
fix: waybar v0.15 divider styles

### DIFF
--- a/styles/modules-center.css
+++ b/styles/modules-center.css
@@ -4,71 +4,71 @@
 
 #keyboard-state label,
 #language {
-	margin-right: 12px;
-	color: @hover-fg;
+  margin-right: 12px;
+  color: @hover-fg;
 }
 
 /*-----------------
     Temperature
 -----------------*/
 
-#custom-left_div.2 {
-	color: @temperature;
+#custom-left_div.2 label {
+  color: @temperature;
 }
 #temperature {
-	background-color: @temperature;
+  background-color: @temperature;
 }
 
 /*------------
     Memory
 ------------*/
 
-#custom-left_div.3 {
-	background-color: @temperature;
-	color: @memory;
+#custom-left_div.3 label {
+  background-color: @temperature;
+  color: @memory;
 }
 #memory {
-	background-color: @memory;
+  background-color: @memory;
 }
 
 /*---------
     CPU
 ---------*/
 
-#custom-left_div.4 {
-	background-color: @memory;
-	color: @cpu;
+#custom-left_div.4 label {
+  background-color: @memory;
+  color: @cpu;
 }
 #cpu {
-	background-color: @cpu;
+  background-color: @cpu;
 }
-#custom-left_inv.1 {
-	color: @cpu;
+#custom-left_inv.1 label {
+  color: @cpu;
 }
 
 /*-----------------
     Distro icon
 -----------------*/
 
-#custom-left_div.5,
-#custom-right_div.2 {
-	color: @accent;
+#custom-left_div.5 label,
+#custom-right_div.2 label {
+  color: @accent;
 }
-#custom-distro {
-	padding: 0 10px 0 5px;
-	background-color: @accent;
-	color: @main-bg;
+#custom-distro label {
+  padding: 0 10px 0 5px;
+  background-color: @accent;
+  color: @main-bg;
 }
 
 /*--------------------
     Idle inhibitor
 --------------------*/
 
-#custom-right_inv.1 {
-	color: @time;
+#custom-right_inv.1 label {
+  color: @time;
 }
 #idle_inhibitor {
-	background-color: @time;
+  background-color: @time;
 }
 
 /*----------
@@ -76,12 +76,12 @@
 ----------*/
 
 #clock.time {
-	padding-right: 6px;
-	background-color: @time;
+  padding-right: 6px;
+  background-color: @time;
 }
-#custom-right_div.3 {
-	background-color: @date;
-	color: @time;
+#custom-right_div.3 label {
+  background-color: @date;
+  color: @time;
 }
 
 /*----------
@@ -89,12 +89,12 @@
 ----------*/
 
 #clock.date {
-	padding-left: 6px;
-	background-color: @date;
+  padding-left: 6px;
+  background-color: @date;
 }
-#custom-right_div.4 {
-	background-color: @tray;
-	color: @date;
+#custom-right_div.4 label {
+  background-color: @tray;
+  color: @date;
 }
 
 /*-----------------
@@ -102,17 +102,17 @@
 -----------------*/
 
 #network {
-	background-color: @tray;
-	padding: 0 6px 0 4px;
+  background-color: @tray;
+  padding: 0 6px 0 4px;
 }
 #bluetooth {
-	background-color: @tray;
-	padding: 0 5px;
+  background-color: @tray;
+  padding: 0 5px;
 }
 #custom-update {
-	background-color: @tray;
-	padding: 0 8px 0 2px;
+  background-color: @tray;
+  padding: 0 8px 0 2px;
 }
-#custom-right_div.5 {
-	color: @tray;
+#custom-right_div.5 label {
+  color: @tray;
 }

--- a/styles/modules-left.css
+++ b/styles/modules-left.css
@@ -2,17 +2,17 @@
     Workspaces
 ----------------*/
 
-#custom-left_div.1,
-#custom-right_div.1 {
-	color: @workspaces;
+#custom-left_div.1 label,
+#custom-right_div.1 label {
+  color: @workspaces;
 }
 #workspaces {
-	padding: 0 1px;
-	background-color: @workspaces;
+  padding: 0 1px;
+  background-color: @workspaces;
 }
 #workspaces button.active label,
 #workspaces button.focused label {
-	color: @accent;
+  color: @accent;
 }
 
 /*------------------
@@ -20,5 +20,5 @@
 ------------------*/
 
 #window {
-	margin: 0 12px;
+  margin: 0 12px;
 }

--- a/styles/modules-right.css
+++ b/styles/modules-right.css
@@ -3,46 +3,46 @@
 ----------------*/
 
 #mpris {
-	padding: 0 12px;
+  padding: 0 12px;
 }
 
 /*------------
     Volume
 ------------*/
 
-#custom-left_div.6 {
-	color: @volume;
+#custom-left_div.6 label {
+  color: @volume;
 }
 #pulseaudio,
 #wireplumber {
-	background-color: @volume;
+  background-color: @volume;
 }
 
 /*----------------
     Brightness
 ----------------*/
 
-#custom-left_div.7 {
-	background-color: @volume;
-	color: @backlight;
+#custom-left_div.7 label {
+  background-color: @volume;
+  color: @backlight;
 }
 #backlight {
-	background-color: @backlight;
+  background-color: @backlight;
 }
 
 /*-------------
     Battery
 -------------*/
 
-#custom-left_div.8 {
-	background-color: @backlight;
-	color: @battery;
+#custom-left_div.8 label {
+  background-color: @backlight;
+  color: @battery;
 }
 #battery {
-	background-color: @battery;
+  background-color: @battery;
 }
-#custom-left_inv.2 {
-	color: @battery;
+#custom-left_inv.2 label {
+  color: @battery;
 }
 
 /*----------------
@@ -50,10 +50,10 @@
 ----------------*/
 
 #custom-power {
-	border-radius: 16px;
-	padding: 0 19px 0 16px;
-	color: @accent;
+  border-radius: 16px;
+  padding: 0 19px 0 16px;
+  color: @accent;
 }
 #custom-power:hover {
-	background-color: @hover-bg;
+  background-color: @hover-bg;
 }


### PR DESCRIPTION
Waybar's v0.15 changes breaks the styling. This fixes the issue by targeting the label widget instead of the custom module container.
# Before
<img width="1366" height="30" alt="image" src="https://github.com/user-attachments/assets/e7e58e77-87b8-4cc2-872c-9ee84b6b2b2e" />

# After
<img width="1366" height="32" alt="20260706_104949" src="https://github.com/user-attachments/assets/82374344-5225-4150-8731-879b42f2412b" />
